### PR TITLE
Add args to groups_count method

### DIFF
--- a/lib/ca-main.php
+++ b/lib/ca-main.php
@@ -1346,10 +1346,15 @@ class CityApi
 		}
 	}
 
-	public function groups_count()
+	public function groups_count($args = NULL)
 	{
 		try {
-			return $this->call_city('GET', CITYAPIBASEURL . '/groups/count');
+
+			$url = CITYAPIBASEURL . '/groups/count';
+			if(!is_null($args)) {
+				$url = $this->add_querystring($url, $args);
+			}
+			return $this->call_city('GET', $url);
 		} 
 		catch (Exception $e) {
 			return $this->handle_exception(__METHOD__, $e->getMessage());


### PR DESCRIPTION
The City supports args for the groups/count endpoint.  I've added support for args to the groups_count method.
